### PR TITLE
Refactor sparse summation and indexing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,23 +9,21 @@ For change history for [MIPS][2], see [mips/CHANGES.md](mips/CHANGES.md).
 For change history for [MOST][3], see [most/CHANGES.md](most/CHANGES.md).
 
 
-since 7.0
----------
+Changes since 7.0
+-----------------
 
 #### 8/15/19
+  - Refactor code in `@opt_model/params_lin_constraint()` and
+    `@opt_model/params_quad_cost()` to speed up sparse matrix construction
+    when there are lots of constraint or cost sets. Results in significant
+    speedups for some problems during problem setup in MOST.
+    *Thanks to Daniel Muldrew.*
   - Remove `active-set` algorithm in `t_opf_dc_ot` for certain versions
     of MATLAB (e.g. R2013b on Mac) to avoid triggering fatal MATLAB bug.
 
 
 Version 7.0 - *Jun 20, 2019*
 ----------------------------
-
-#### 7/10/19
-  - Refactor code in `@opt_model/params_lin_constraint()` and
-    `@opt_model/params_quad_cost()` to speed up sparse matrix construction.
-    Results in significant speedups for some problems during problem setup
-    in MOST.
-    *Thanks to Daniel Muldrew.*
 
 #### 6/20/19
   - Release 7.0.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,13 @@ since 7.0
 Version 7.0 - *Jun 20, 2019*
 ----------------------------
 
+#### 7/10/19
+  - Refactor code in `@opt_model/params_lin_constraint()` and
+    `@opt_model/params_quad_cost()` to speed up sparse matrix construction.
+    Results in significant speedups for some problems during problem setup
+    in MOST.
+    *Thanks to Daniel Muldrew.*
+
 #### 6/20/19
   - Release 7.0.
   - Add `CITATION` file.

--- a/docs/src/MATPOWER-manual/MATPOWER-manual.tex
+++ b/docs/src/MATPOWER-manual/MATPOWER-manual.tex
@@ -8301,6 +8301,65 @@ available even if it had an expired license or failed for some other reason.
 \end{itemize}
 
 
+\clearpage
+\subsection{Version 7.1 (or whatever ends up being next) -- released ??? ??, 20??}
+\label{app:v71}
+
+The \href{https://matpower.org/docs/MATPOWER-manual-7.1.pdf}{\matpower{} 7.1 User's Manual} is available online.\footnote{\url{https://matpower.org/docs/MATPOWER-manual-7.1.pdf}}
+
+\subsubsection*{New Features}
+\begin{itemize}
+\item Something cool. \emph{Thanks to Fulano.}
+\item New options:
+    \begin{itemize}
+    \item 
+    \end{itemize}
+\item New functions:
+    \begin{itemize}
+    \item 
+    \end{itemize}
+\end{itemize}
+
+% \clearpage
+\subsubsection*{New Case Files}
+\begin{itemize}
+\item 
+    \begin{itemize}
+        \setlength{\itemsep}{6pt}
+        \setlength{\parskip}{-9pt}
+%        \setlength{\parsep}{-3pt}
+        \item \code{case\_????} -- description
+    \end{itemize}
+\end{itemize}
+
+% \clearpage
+\subsubsection*{New Documentation}
+\begin{itemize}
+    \item 
+\end{itemize}
+
+\subsubsection*{Other Improvements}
+\begin{itemize}
+\item Significant speedup for some problems when constructing sparse matrices for linear constraints or quadratic costs (e.g. during problem setup in \most{}).
+\emph{Thanks to Daniel Muldrew.}
+\item Deprecated functions:
+    \begin{itemize}
+    \item \code{foo()} -- use \code{bar()} instead.
+    \end{itemize}
+\end{itemize}
+
+% \clearpage
+\subsubsection*{Bugs Fixed}
+\begin{itemize}
+\item Fix bug \#999 where . \emph{Thanks to Fulano.}
+\end{itemize}
+
+\subsubsection*{Incompatible Changes}
+\begin{itemize}
+\item 
+\end{itemize}
+
+
 \end{appendices}
 
 

--- a/lib/@opt_model/get_cost_params.m
+++ b/lib/@opt_model/get_cost_params.m
@@ -34,10 +34,10 @@ cp = om.params_legacy_cost();
 if nargin > 1
     if getN(om, 'cost', name)
         if nargin < 3 || isempty(idx)
-            if prod(size(om.cost.idx.i1.(name))) == 1
+            if numel(om.cost.idx.i1.(name)) == 1    %% simple named set
                 i1 = om.cost.idx.i1.(name);
                 iN = om.cost.idx.iN.(name);
-            else
+            else                                    %% indexing required
                 error('@opt_model/get_cost_params: cost set ''%s'' requires an idx arg', name);
             end
         else

--- a/lib/@opt_model/params_legacy_cost.m
+++ b/lib/@opt_model/params_legacy_cost.m
@@ -73,7 +73,7 @@ if nargin > 1       %% individual set
         idx = {};
     end
     if isempty(idx)                 %% name, no index provided
-        if prod(size(om.cost.idx.i1.(name))) == 1   %% simple named set
+        if numel(om.cost.idx.i1.(name)) == 1    %% simple named set
             N  = om.cost.data.N.( name);
             Cw = om.cost.data.Cw.(name);
             [nw, nx] = size(N);
@@ -109,7 +109,7 @@ if nargin > 1       %% individual set
                     iN = om.cost.idx.iN.(name);     %% ending row index
                 end
             end
-        else                                        %% indexing required
+        else                                    %% indexing required
             error('@opt_model/params_legacy_cost: legacy cost set ''%s'' requires an IDX arg', name);
         end
     else                            %% indexed named set

--- a/lib/@opt_model/params_lin_constraint.m
+++ b/lib/@opt_model/params_lin_constraint.m
@@ -79,7 +79,7 @@ else                %% aggregate
     if isempty(cache)       %% build the aggregate
         nx = om.var.N;          %% number of variables
         nlin = om.lin.N;        %% number of linear constraints
-        At = sparse(nx, nlin);  %% transpose of constraint matrix
+        A_ijv = cell(om.lin.NS, 3); %% indices/values to construct A
         u = Inf(nlin, 1);       %% upper bound
         l = -u;                 %% lower bound
 
@@ -90,27 +90,25 @@ else                %% aggregate
             [Ak, lk, uk, vs, i1, iN] = om.params_lin_constraint(name, idx);
             [mk, nk] = size(Ak);        %% size of Ak
             if mk
-                Akt_full = sparse(nx, nlin);
-                if isempty(vs)
-                    if nk == nx     %% full size
-                        Akt_full(:, i1:iN) = Ak';
-                    else            %% vars added since adding this cost set
-                        Ak_all_cols = sparse(mk, nx);
-                        Ak_all_cols(:, 1:nk) = Ak;
-                        Akt_full(:, i1:iN) = Ak_all_cols';
-                    end
-                else
-                    jj = om.varsets_idx(vs);    %% indices for var set
-                    Ak_all_cols = sparse(mk, nx);
-                    Ak_all_cols(:, jj) = Ak;
-                    Akt_full(:, i1:iN) = Ak_all_cols';
+                % find nonzero sub indices and values
+                [i, j, v] = find(Ak);
+                if mk == 1  %% force col vectors for single row Ak
+                    i = i'; j = j'; v = v';
                 end
-                At = At + Akt_full;
+
+                if isempty(vs)
+                    A_ijv(k,:) = {i+(i1-1), j, v};
+                else
+                    jj = om.varsets_idx(vs)';    %% indices for var set
+                    A_ijv(k,:) = {i+(i1-1), jj(j), v};
+                end
                 l(i1:iN) = lk;
                 u(i1:iN) = uk;
             end
         end
-        A = At';
+        A = sparse( vertcat(A_ijv{:,1}), ...
+                    vertcat(A_ijv{:,2}), ...
+                    vertcat(A_ijv{:,3}), nlin, nx);
 
         %% cache aggregated parameters
         om.lin.params = struct('A', A, 'l', l, 'u', u);

--- a/lib/@opt_model/params_lin_constraint.m
+++ b/lib/@opt_model/params_lin_constraint.m
@@ -43,7 +43,7 @@ if nargin > 1       %% individual set
         idx = {};
     end
     if isempty(idx)
-        if prod(size(om.lin.idx.i1.(name))) == 1
+        if numel(om.lin.idx.i1.(name)) == 1     %% simple named set
             A = om.lin.data.A.(name);
             l = om.lin.data.l.(name);
             u = om.lin.data.u.(name);
@@ -54,7 +54,7 @@ if nargin > 1       %% individual set
                     iN = om.lin.idx.iN.(name);      %% ending row index
                 end
             end
-        else
+        else                                    %% indexing required
             error('@opt_model/params_lin_constraint: linear constraint set ''%s'' requires an IDX arg', name);
         end
     else

--- a/lib/@opt_model/params_quad_cost.m
+++ b/lib/@opt_model/params_quad_cost.m
@@ -37,14 +37,14 @@ if nargin > 1       %% individual set
         idx = {};
     end
     if isempty(idx)                 %% name, no index provided
-        if prod(size(om.qdc.idx.i1.(name))) == 1    %% simple named set
+        if numel(om.qdc.idx.i1.(name)) == 1     %% simple named set
             Q = om.qdc.data.Q.(name);
             c = om.qdc.data.c.(name);
             k = om.qdc.data.k.(name);
             if nargout > 3
                 vs = om.qdc.data.vs.(name);
             end
-        else                                        %% indexing required
+        else                                    %% indexing required
             error('@opt_model/params_quad_cost: quadratic cost set ''%s'' requires an IDX arg', name);
         end
     else                            %% indexed named set

--- a/lib/t/t_opf_model.m
+++ b/lib/t/t_opf_model.m
@@ -13,7 +13,7 @@ if nargin < 1
     quiet = 0;
 end
 
-num_tests = 591;
+num_tests = 593;
 
 t_begin(num_tests, quiet);
 
@@ -416,6 +416,13 @@ for i = 1:2
         t_ok(om.get('lin', 'NS') == lNS, sprintf('%s : lin.NS = %d', t, lNS));
     end
 end
+
+t = 'om.add_lin_constraint(''onerow'', A, l, u)';
+A = sparse([1 1 1]', [1:3]', [-1 -2 -3]', 1, vN);
+om.add_lin_constraint('onerow', A, 0, Inf);
+lNS = lNS + 1; lN = lN + 1;
+t_ok(om.getN('lin') == lN, sprintf('%s : lin.N  = %d', t, lN));
+t_ok(om.get('lin', 'NS') == lNS, sprintf('%s : lin.NS = %d', t, lNS));
 
 %%-----  add_nln_constraint (equality)  -----
 t = 'add_nln_constraint (equality)';


### PR DESCRIPTION
We profiled our MOST simulation using the Matlab profiler and found that the majority of our computation time was due to indexed assignment and summation of sparse matrices.

Refactoring these functions with a new implementation modeled after this blog post:
https://blogs.mathworks.com/loren/2007/03/01/creating-sparse-finite-element-matrices-in-matlab/
results in significant performance improvement for our model.

We have done some testing of the changes within the debugger and plan to add an automated test. Suggestions of the best way to do this would be welcome...