### PR TITLE
Fix #71, changing sparsity structure for OPF Jacobian / Hessian

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,13 @@ For change history for [MOST][3], see [most/CHANGES.md](most/CHANGES.md).
 Changes since 7.0
 -----------------
 
+#### 8/21/19
+  - Fix OPF [issue #71][24] for IPOPT and Knitro where structure of
+    Jacobian and/or Hessian could change from the structure provided
+    (i.e. elements with value of zero were being eliminated from the
+    sparsity structure).
+    *Thanks to Drosos Kourounis.*
+
 #### 8/16/19
   - Fix [issue #77][23] where incorrect indexing could cause fatal error
     in OPF with additional nonlinear constraints.
@@ -2913,3 +2920,4 @@ First Public Release – *Jun 25, 1997*
 [21]: https://github.com/MATPOWER/matpower/pull/70
 [22]: https://github.com/MATPOWER/matpower/issues/79
 [23]: https://github.com/MATPOWER/matpower/issues/77
+[24]: https://github.com/MATPOWER/matpower/issues/71

--- a/docs/src/MATPOWER-manual/MATPOWER-manual.tex
+++ b/docs/src/MATPOWER-manual/MATPOWER-manual.tex
@@ -8353,6 +8353,10 @@ The \href{https://matpower.org/docs/MATPOWER-manual-7.1.pdf}{\matpower{} 7.1 Use
 \begin{itemize}
 \item Fix bug \#77 where incorrect indexing could cause fatal error
 in OPF with additional nonlinear constraints. \emph{Thanks to Sergio Garcia.}
+\item Fix OPF issue \#71 for \ipopt{} and \knitro{} where structure of
+Jacobian and/or Hessian could change from the structure provided
+(i.e. elements with value of zero were being eliminated from the
+sparsity structure). \emph{Thanks to Drosos Kourounis.}
 \end{itemize}
 
 \subsubsection*{Incompatible Changes}

--- a/lib/ipoptopf_solver.m
+++ b/lib/ipoptopf_solver.m
@@ -154,12 +154,12 @@ nA = size(A, 1);                %% number of original linear constraints
 % ]);
 randx = rand(size(x0));
 [h, g, dh, dg] = opf_consfcn(randx, om, Ybus, Yf(il,:), Yt(il,:), mpopt, il);
-dh(dh ~= 0) = 1e-32;    %% set non-zero entries to tiny value (for adding later)
-dg(dg ~= 0) = 1e-32;    %% set non-zero entries to tiny value (for adding later)
+dh(dh ~= 0) = 1e-20;    %% set non-zero entries to tiny value (for adding later)
+dg(dg ~= 0) = 1e-20;    %% set non-zero entries to tiny value (for adding later)
 Js = [dg'; dh'; A];
 lam = struct('eqnonlin', rand(size(dg,2),1), 'ineqnonlin', rand(size(dh,2),1));
 Hs = opf_hessfcn(randx, lam, 1, om, Ybus, Yf(il,:), Yt(il,:), mpopt, il);
-Hs(Hs ~= 0) = 1e-32;    %% set non-zero entries to tiny value (for adding later)
+Hs(Hs ~= 0) = 1e-20;    %% set non-zero entries to tiny value (for adding later)
 neq = length(g);
 niq = length(h);
 

--- a/lib/ktropf_solver.m
+++ b/lib/ktropf_solver.m
@@ -158,12 +158,12 @@ nl2 = length(il);           %% number of constrained lines
 % ];
 randx = rand(size(x0));
 [h, g, dh, dg] = opf_consfcn(randx, om, Ybus, Yf(il,:), Yt(il,:), mpopt, il);
-dh(dh ~= 0) = 1e-32;    %% set non-zero entries to tiny value (for adding later)
-dg(dg ~= 0) = 1e-32;    %% set non-zero entries to tiny value (for adding later)
+dh(dh ~= 0) = 1e-20;    %% set non-zero entries to tiny value (for adding later)
+dg(dg ~= 0) = 1e-20;    %% set non-zero entries to tiny value (for adding later)
 Js = [dh'; dg'];
 lam = struct('eqnonlin', rand(size(dg,2),1), 'ineqnonlin', rand(size(dh,2),1) );
 Hs = opf_hessfcn(randx, lam, 1, om, Ybus, Yf(il,:), Yt(il,:), mpopt, il);
-Hs(Hs ~= 0) = 1e-32;    %% set non-zero entries to tiny value (for adding later)
+Hs(Hs ~= 0) = 1e-20;    %% set non-zero entries to tiny value (for adding later)
 neq = length(g);
 niq = length(h);
 

--- a/lib/opf_consfcn.m
+++ b/lib/opf_consfcn.m
@@ -1,4 +1,4 @@
-function [h, g, dh, dg] = opf_consfcn(x, om, Ybus, Yf, Yt, mpopt, il, varargin)
+function [h, g, dh, dg] = opf_consfcn(x, om, Ybus, Yf, Yt, mpopt, il, dhs, dgs)
 %OPF_CONSFCN  Evaluates nonlinear constraints and their Jacobian for OPF.
 %   [H, G, DH, DG] = OPF_CONSFCN(X, OM, YBUS, YF, YT, MPOPT, IL)
 %
@@ -17,6 +17,10 @@ function [h, g, dh, dg] = opf_consfcn(x, om, Ybus, Yf, Yt, mpopt, il, varargin)
 %          branches with flow limits (all others are assumed to be
 %          unconstrained). The default is [1:nl] (all branches).
 %          YF and YT contain only the rows corresponding to IL.
+%     DHS : (optional) sparse matrix with tiny non-zero values specifying
+%          the fixed sparsity structure that the resulting DH should match
+%     DGS : (optional) sparse matrix with tiny non-zero values specifying
+%          the fixed sparsity structure that the resulting DG should match
 %
 %   Outputs:
 %     H  : vector of inequality constraint values (flow limits)
@@ -54,4 +58,32 @@ else                %% constraints and derivatives
     [h, dh] = om.eval_nln_constraint(x, 0); %% inequalities (branch flow limits)
     dg = dg';
     dh = dh';
+
+    %% force specified sparsity structure
+    if nargin > 7
+        %% add sparse structure (with tiny values) to current matrices to
+        %% ensure that sparsity structure matches that supplied
+        dg = dg + dgs;
+        dh = dh + dhs;
+
+%         %% check sparsity structure against that supplied
+%         if nnz(dg) ~= nnz(dgs)
+%             fprintf('=====> nnz(dg) is %d, expected %d <=====\n', nnz(dg), nnz(dgs));
+%         else
+%             [idgs, jdgs] = find(dgs);
+%             [idg, jdg] = find(dg);
+%             if any(idg ~= idgs) || any(jdg ~= jdgs)
+%                 fprintf('=====> structure of dg is not as expected <=====\n');
+%             end
+%         end
+%         if nnz(dh) ~= nnz(dhs)
+%             fprintf('=====> nnz(dh) is %d, expected %d <=====\n', nnz(dh), nnz(dhs));
+%         else
+%             [idhs, jdhs] = find(dhs);
+%             [idh, jdh] = find(dh);
+%             if any(idh ~= idhs) || any(jdh ~= jdhs)
+%                 fprintf('=====> structure of dh is not as expected <=====\n');
+%             end
+%         end
+    end
 end

--- a/lib/opf_hessfcn.m
+++ b/lib/opf_hessfcn.m
@@ -1,4 +1,4 @@
-function Lxx = opf_hessfcn(x, lambda, cost_mult, om, Ybus, Yf, Yt, mpopt, il)
+function Lxx = opf_hessfcn(x, lambda, cost_mult, om, Ybus, Yf, Yt, mpopt, il, Hs)
 %OPF_HESSFCN  Evaluates Hessian of Lagrangian for AC OPF.
 %   LXX = OPF_HESSFCN(X, LAMBDA, COST_MULT, OM, YBUS, YF, YT, MPOPT, IL)
 %
@@ -21,6 +21,8 @@ function Lxx = opf_hessfcn(x, lambda, cost_mult, om, Ybus, Yf, Yt, mpopt, il)
 %          branches with flow limits (all others are assumed to be
 %          unconstrained). The default is [1:nl] (all branches).
 %          YF and YT contain only the rows corresponding to IL.
+%     HS : (optional) sparse matrix with tiny non-zero values specifying
+%          the fixed sparsity structure that the resulting LXX should match
 %
 %   Outputs:
 %     LXX : Hessian of the Lagrangian.
@@ -93,3 +95,22 @@ if 0
 end
 
 Lxx = d2f + d2G + d2H;
+
+
+%% force specified sparsity structure
+if nargin > 9
+    %% add sparse structure (with tiny values) to current matrices to
+    %% ensure that sparsity structure matches that supplied
+    Lxx = Lxx + Hs;
+
+%     %% check sparsity structure against that supplied
+%     if nnz(Lxx) ~= nnz(Hs)
+%         fprintf('=====> nnz(Lxx) is %d, expected %d <=====\n', nnz(Lxx), nnz(Hs));
+%     else
+%         [iHs, jHs] = find(Hs);
+%         [iH, jH] = find(Lxx);
+%         if any(iH ~= iHs) || any(jH ~= jHs)
+%             fprintf('=====> structure of Lxx is not as expected <=====\n');
+%         end
+%     end
+end


### PR DESCRIPTION
This addresses the issue described in #71.

In my testing, I've confirmed that without this fix, the Jacobian and Hessian matrices returned by `opt_consfcn()` and `opf_hessfcn()` do indeed sometimes have a different sparsity structure (more zero entries) than the one generated by using a random _x_, the one that is passed to IPOPT and Knitro as the sparsity pattern.

My question is, does this actually cause errors? Do IPOPT and/or Knitro actually end up using the wrong matrix in this case? @throssoskourounis, do you know what errors result from this?

The reason I ask is that, not only have I never seen IPOPT or Knitro complain, I have also not observed any cases where there was a noticeable improvement in performance (e.g. fewer iterations to solve) from applying this fix.

Thoughts?