### PR TITLE
Fix incorrect power flow results with pf.enforce_q_lims and ZIP loads

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,11 @@ For change history for [MOST][3], see [most/CHANGES.md](most/CHANGES.md).
 Changes since 7.0
 -----------------
 
+#### 2/28/20
+  - Fix [bug #89][26] where running a power flow with `pf.enforce_q_lims`
+    enabled and voltage dependent ZIP loads produced incorrect results.
+    *Thanks to Florian.*
+
 #### 2/27/20
   - Add `copy()` method to `@opt_model` class to get around issues
     with inheritance in constructors that was preventing copy constructor
@@ -2971,3 +2976,4 @@ First Public Release – *Jun 25, 1997*
 [23]: https://github.com/MATPOWER/matpower/issues/77
 [24]: https://github.com/MATPOWER/matpower/issues/71
 [25]: https://github.com/MATPOWER/matpower/issues/90
+[26]: https://github.com/MATPOWER/matpower/issues/89

--- a/docs/src/MATPOWER-manual/MATPOWER-manual.tex
+++ b/docs/src/MATPOWER-manual/MATPOWER-manual.tex
@@ -8425,6 +8425,7 @@ Jacobian and/or Hessian could change from the structure provided
 sparsity structure). \emph{Thanks to Drosos Kourounis.}
 \item Artelys Knitro 12.1 compatibility fix.
 \item Fix CPLEX 12.10 compatibility issue \#90.
+\item Fix bug \#89 where running a power flow with \code{pf.enforce\_q\_lims} enabled and voltage dependent ZIP loads produced incorrect results. \emph{Thanks to Florian.}
 \end{itemize}
 
 \subsubsection*{Incompatible Changes}

--- a/lib/runpf.m
+++ b/lib/runpf.m
@@ -59,7 +59,7 @@ function [MVAbase, bus, gen, branch, success, et] = ...
 %   See also RUNDCPF.
 
 %   MATPOWER
-%   Copyright (c) 1996-2019, Power Systems Engineering Research Center (PSERC)
+%   Copyright (c) 1996-2020, Power Systems Engineering Research Center (PSERC)
 %   by Ray Zimmerman, PSERC Cornell
 %   Enforcing of generator Q limits inspired by contributions
 %   from Mu Lin, Lincoln University, New Zealand (1/14/05).
@@ -348,12 +348,6 @@ if ~isempty(mpc.bus)
 
                     %% convert to PQ bus
                     gen(mx, QG) = fixedQg(mx);      %% set Qg to binding limit
-                    gen(mx, GEN_STATUS) = 0;        %% temporarily turn off gen,
-                    for i = 1:length(mx)            %% (one at a time, since
-                        bi = gen(mx(i), GEN_BUS);   %%  they may be at same bus)
-                        bus(bi, [PD,QD]) = ...      %% adjust load accordingly,
-                            bus(bi, [PD,QD]) - gen(mx(i), [PG,QG]);
-                    end
                     if length(ref) > 1 && any(bus(gen(mx, GEN_BUS), BUS_TYPE) == REF)
                         error('runpf: Sorry, MATPOWER cannot enforce Q limits for slack buses in systems with multiple slacks.');
                     end
@@ -381,14 +375,6 @@ if ~isempty(mpc.bus)
             end
         end
         if qlim && ~isempty(limited)
-            %% restore injections from limited gens (those at Q limits)
-            gen(limited, QG) = fixedQg(limited);    %% restore Qg value,
-            for i = 1:length(limited)               %% (one at a time, since
-                bi = gen(limited(i), GEN_BUS);      %%  they may be at same bus)
-                bus(bi, [PD,QD]) = ...              %% re-adjust load,
-                    bus(bi, [PD,QD]) + gen(limited(i), [PG,QG]);
-            end
-            gen(limited, GEN_STATUS) = 1;               %% and turn gen back on
             if ref ~= ref0
                 %% adjust voltage angles to make original ref bus correct
                 bus(:, VA) = bus(:, VA) - bus(ref0, VA) + Varef0;


### PR DESCRIPTION
This PR addresses #89, not as proposed in the work-around, but rather by simply not moving the generation to the `PD` and `QD` columns of `bus` in the first place. Simply setting `QG` and converting the bus type is enough, since the generator injections at PQ buses are handled properly. Not sure why I was doing it that way in the first place, unless it was implemented before generator injections at PQ buses were handled properly.

In any case, I would appreciate help in testing that I didn't break anything, especially for cases with multiple generators at a bus. It seemed to work in my own simple tests, but additional eyes on the details would be appreciated.