### PR TITLE
Fix loadcase string input

### DIFF
--- a/lib/loadcase.m
+++ b/lib/loadcase.m
@@ -188,7 +188,7 @@ if info == 0    %% no errors
 else            %% we have a problem captain
     switch info
         case 1,
-            error('loadcase: input arg should be a struct or a string containing a filename');
+            error('loadcase: input arg should be a struct or a char array/string containing a filename');
         case 2,
             error('loadcase: specified case not in MATLAB''s search path');
         case 3,

--- a/lib/loadcase.m
+++ b/lib/loadcase.m
@@ -50,6 +50,9 @@ else
 end
 
 %%-----  read data into struct  -----
+if isstring(casefile)
+    casefile = char(casefile)
+end
 if ischar(casefile)
     [pathstr, fname, ext] = fileparts(casefile);
     if isempty(ext)

--- a/lib/loadcase.m
+++ b/lib/loadcase.m
@@ -50,7 +50,7 @@ else
 end
 
 %%-----  read data into struct  -----
-if isstring(casefile)
+if isa(casefile, 'string')
     casefile = char(casefile);
 end
 if ischar(casefile)

--- a/lib/loadcase.m
+++ b/lib/loadcase.m
@@ -51,7 +51,7 @@ end
 
 %%-----  read data into struct  -----
 if isstring(casefile)
-    casefile = char(casefile)
+    casefile = char(casefile);
 end
 if ischar(casefile)
     [pathstr, fname, ext] = fileparts(casefile);


### PR DESCRIPTION
Closes #99

Fix issue #99 
Proposes a minimal fix to enable passing cases defined by `string` variables.
Now the following works:
```matlab
loadcase(pwd + "/.data/case14_tightened.m")
```