### PR TITLE
exclude `.` from oldpaths

### DIFF
--- a/install_matpower.m
+++ b/install_matpower.m
@@ -284,6 +284,7 @@ if ~isempty(oldpaths)
 
     %% remove old paths
     if rm_oldpaths
+        oldpaths = oldpaths(~strcmp(oldpaths, '.')); 
         rmpath(oldpaths{:});
         if verbose
             fprintf(div_line);


### PR DESCRIPTION
Exclude `.` from `oldpaths`, fix https://github.com/MATPOWER/matpower/issues/141#issuecomment-2395012364