### PR TITLE
Add tap ratio to three-phase transformers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,11 @@ For change history for [MOST][3], see [most/CHANGES.md](most/CHANGES.md).
 since 8.0
 ---------
 
+#### 5/10/25
+  - Add off-nominal tap ratio parameter to prototype three-phase
+    transformer model.
+    *Thanks to Wilson González Vanegas.*
+
 #### 4/9/25
   - Fix typos that cause fatal errors with GNU Octave 10.x.
 

--- a/docs/sphinx/source/howto/three-phase.rst
+++ b/docs/sphinx/source/howto/three-phase.rst
@@ -146,10 +146,10 @@ The prototype examples included in |MATPOWER| 8 simply define a few extra fields
 ::
 
     function mpc = t_case3p_a
-    %T_CASE3P_A   Four bus, unbalanced 3-phase test case.
+    % t_case3p_a - Four bus, unbalanced 3-phase test case.
     %
-    % This data comes from 4Bus-YY-UnB.DSS, a modified version (with unbalanced
-    % load) of 4Bus-YY-Bal.DSS [1], the OpenDSS 4 bus IEEE test case with
+    % This data comes from ``4Bus-YY-UnB.DSS``, a modified version (with unbalanced
+    % load) of ``4Bus-YY-Bal.DSS`` [1], the OpenDSS 4 bus IEEE test case with
     % grounded-wye to grounded-wye transformer.
     %
     % [1] https://sourceforge.net/p/electricdss/code/HEAD/tree/trunk/Distrib/IEEETestCases/4Bus-YY-Bal/4Bus-YY-Bal.DSS
@@ -189,9 +189,9 @@ The prototype examples included in |MATPOWER| 8 simply define a few extra fields
     ];
     
     %% transformer
-    %	xfid	fbus	tbus	status	R	X	basekVA	basekV
+    %	xfid	fbus	tbus	status	R	X	basekVA	basekV	ratio
     mpc.xfmr3p = [
-        1	2	3	1	0.01	0.06	6000	12.47;
+        1	2	3	1	0.01	0.06	6000	12.47	1;
     ];
     
     %% load
@@ -266,6 +266,7 @@ Col  Name       Description — *see also* :class:`mp.dme_xfmr3p`
   6  X          reactance (p.u. on transformer base)
   7  basekVA    transformer per-unit power base in kVA
   8  basekV     transformer per-unit voltage base in kV
+  9  ratio      transformer off-nominal turns ratio
 ===  =========  =====================
 
 

--- a/docs/src/MATPOWER-manual/MATPOWER-manual.tex
+++ b/docs/src/MATPOWER-manual/MATPOWER-manual.tex
@@ -8656,6 +8656,8 @@ The \href{https://matpower.org/docs/MATPOWER-manual-8.0.1-dev.pdf}{\matpower{} 8
 
 \subsubsection*{New Features}
 \begin{itemize}
+\item Add off-nominal tap ratio parameter to prototype three-phase transformer model.
+\emph{Thanks to Wilson Gonz\'alez Vanegas.}
 \item
 \item New options:
 \begin{itemize}

--- a/lib/+mp/dmce_xfmr3p_mpc2.m
+++ b/lib/+mp/dmce_xfmr3p_mpc2.m
@@ -2,8 +2,9 @@ classdef dmce_xfmr3p_mpc2 < mp.dmc_element % & mp.dmce_xfmr3p
 % mp.dmce_xfmr3p_mpc2 - Data model converter element for 3-phase transformer for |MATPOWER| case v2.
 
 %   MATPOWER
-%   Copyright (c) 2021-2023s, Power Systems Engineering Research Center (PSERC)
+%   Copyright (c) 2021-2025, Power Systems Engineering Research Center (PSERC)
 %   by Ray Zimmerman, PSERC Cornell
+%   and Wilson Gonzalez Vanegas, Universidad Nacional de Colombia Sede Manizales
 %
 %   This file is part of MATPOWER.
 %   Covered by the 3-clause BSD License (see LICENSE file for details).

--- a/lib/+mp/dmce_xfmr3p_mpc2.m
+++ b/lib/+mp/dmce_xfmr3p_mpc2.m
@@ -38,6 +38,7 @@ classdef dmce_xfmr3p_mpc2 < mp.dmc_element % & mp.dmce_xfmr3p
             vmap.x{2}       = 6;
             vmap.base_kva{2}= 7;
             vmap.base_kv{2} = 8;
+            vmap.tm{2}      = 9;
             vmap.pl1_fr     = {'num', 0};   %% zeros
             vmap.ql1_fr     = {'num', 0};   %% zeros
             vmap.pl2_fr     = {'num', 0};   %% zeros

--- a/lib/+mp/dme_xfmr3p.m
+++ b/lib/+mp/dme_xfmr3p.m
@@ -31,8 +31,9 @@ classdef dme_xfmr3p < mp.dm_element
 %   ============  =========  =============================================
 
 %   MATPOWER
-%   Copyright (c) 2021-2024, Power Systems Engineering Research Center (PSERC)
+%   Copyright (c) 2021-2025, Power Systems Engineering Research Center (PSERC)
 %   by Ray Zimmerman, PSERC Cornell
+%   and Wilson Gonzalez Vanegas, Universidad Nacional de Colombia Sede Manizales
 %
 %   This file is part of MATPOWER.
 %   Covered by the 3-clause BSD License (see LICENSE file for details).

--- a/lib/+mp/dme_xfmr3p.m
+++ b/lib/+mp/dme_xfmr3p.m
@@ -15,6 +15,7 @@ classdef dme_xfmr3p < mp.dm_element
 %   ``x``         *double*   series reactance *(p.u.)*
 %   ``base_kva``  *double*   transformer kVA base *(kVA)*
 %   ``base_kv``   *double*   transformer kV base *(kV)*
+%   ``tm`     `   *double*   transformer off-nominal turns ratio
 %   ``pl1_fr``    *double*   phase 1 active power injection at "from" end *(kW)*
 %   ``ql1_fr``    *double*   phase 1 reactive power injection at "from" end *(kVAr)*
 %   ``pl2_fr``    *double*   phase 2 active power injection at "from" end *(kW)*
@@ -44,10 +45,10 @@ classdef dme_xfmr3p < mp.dm_element
         x       % series reactance (p.u.) for transformers that are on
         base_kva%
         base_kv %
+        tm      % transformer off-nominal turns ratio for transformers that are on
 %         g_to    %% shunt conductance (p.u.) at "to" end for transformers that are on
 %         b_fr    %% shunt susceptance (p.u.) at "from" end for transformers that are on
 %         b_to    %% shunt susceptance (p.u.) at "to" end for transformers that are on
-%         tm      %% transformer off-nominal turns ratio for transformers that are on
 %         ta      %% xformer phase-shift angle (radians) for transformers that are on
 %         rate_a  %% long term flow limit (p.u.) for transformers that are on
     end     %% properties
@@ -81,7 +82,7 @@ classdef dme_xfmr3p < mp.dm_element
         function names = main_table_var_names(obj)
             %
             names = horzcat( main_table_var_names@mp.dm_element(obj), ...
-                {'bus_fr', 'bus_to', 'r', 'x', 'base_kva', 'base_kv', ...
+                {'bus_fr', 'bus_to', 'r', 'x', 'base_kva', 'base_kv', 'tm', ...
                  'pl1_fr', 'ql1_fr', 'pl2_fr', 'ql2_fr', 'pl3_fr', 'ql3_fr', ...
                  'pl1_to', 'ql1_to', 'pl2_to', 'ql2_to', 'pl3_to', 'ql3_to' ...
                  });
@@ -133,6 +134,7 @@ classdef dme_xfmr3p < mp.dm_element
             obj.x = obj.tab.x(obj.on);
             obj.base_kva = obj.tab.base_kva(obj.on);
             obj.base_kv  = obj.tab.base_kv(obj.on);
+            obj.tm = obj.tab.tm(obj.on);
         end
 
         function obj = pretty_print(obj, dm, section, out_e, mpopt, fd, pp_args)

--- a/lib/+mp/nme_xfmr3p.m
+++ b/lib/+mp/nme_xfmr3p.m
@@ -36,17 +36,24 @@ classdef nme_xfmr3p < mp.nm_element & mp.form_acp
             dme = obj.data_model_element(dm);
             bus_dme = dm.elements.(dme.cxn_type);
             nk = 3*obj.nk;
+            tm = ones(obj.nk, 1);       %% default tap ratio = 1
+            i = find(dme.tm);           %% indices of non-zero tap ratios
+            tm(i) = dme.tm(i);          %% assign non-zero tap ratios
 
             base_kv = bus_dme.tab.base_kv(bus_dme.on(dme.fbus(dme.on)));
             z = dm.base_kva * (dme.r + 1j * dme.x) ./ dme.base_kva .* ...
                 (dme.base_kv ./ ( base_kv / sqrt(3))) .^ 2;
-            y = 1 ./ z;
-            Y = [y;y;y];
+            y = 1 ./ z;                 %% series admitance p.u. @system bases 
+            
+            yff = y ./ (tm .^ 2);   Yff = [yff; yff; yff];
+            ytt = y;                Ytt = [ytt; ytt; ytt];
+            yft = - y ./ tm;        Yft = [yft; yft; yft];
+            ytf = yft;              Ytf = [ytf; ytf; ytf];
 
             obj.Y = sparse( ...
                 [1:nk 1:nk nk+1:2*nk nk+1:2*nk]', ...
                 [1:nk nk+1:2*nk 1:nk nk+1:2*nk]', ...
-                [Y; -Y; -Y; Y], 2*nk, 2*nk );
+                [Yff; Yft; Ytf; Ytt], 2*nk, 2*nk );
         end
     end     %% methods
 end         %% classdef

--- a/lib/+mp/nme_xfmr3p.m
+++ b/lib/+mp/nme_xfmr3p.m
@@ -36,19 +36,16 @@ classdef nme_xfmr3p < mp.nm_element & mp.form_acp
             dme = obj.data_model_element(dm);
             bus_dme = dm.elements.(dme.cxn_type);
             nk = 3*obj.nk;
-            tm = ones(obj.nk, 1);       %% default tap ratio = 1
-            i = find(dme.tm);           %% indices of non-zero tap ratios
-            tm(i) = dme.tm(i);          %% assign non-zero tap ratios
 
             base_kv = bus_dme.tab.base_kv(bus_dme.on(dme.fbus(dme.on)));
             z = dm.base_kva * (dme.r + 1j * dme.x) ./ dme.base_kva .* ...
                 (dme.base_kv ./ ( base_kv / sqrt(3))) .^ 2;
             y = 1 ./ z;                 %% series admitance p.u. @system bases 
             
-            yff = y ./ (tm .^ 2);   Yff = [yff; yff; yff];
-            ytt = y;                Ytt = [ytt; ytt; ytt];
-            yft = - y ./ tm;        Yft = [yft; yft; yft];
-            ytf = yft;              Ytf = [ytf; ytf; ytf];
+            yff = y ./ (dme.tm .^ 2);   Yff = [yff; yff; yff];
+            ytt = y;                    Ytt = [ytt; ytt; ytt];
+            yft = - y ./ dme.tm;        Yft = [yft; yft; yft];
+            ytf = yft;                  Ytf = [ytf; ytf; ytf];
 
             obj.Y = sparse( ...
                 [1:nk 1:nk nk+1:2*nk nk+1:2*nk]', ...

--- a/lib/+mp/nme_xfmr3p.m
+++ b/lib/+mp/nme_xfmr3p.m
@@ -8,8 +8,9 @@ classdef nme_xfmr3p < mp.nm_element & mp.form_acp
 % transformers and inherits from mp.form_acp.
 
 %   MATPOWER
-%   Copyright (c) 2021-2024, Power Systems Engineering Research Center (PSERC)
+%   Copyright (c) 2021-2025, Power Systems Engineering Research Center (PSERC)
 %   by Ray Zimmerman, PSERC Cornell
+%   and Wilson Gonzalez Vanegas, Universidad Nacional de Colombia Sede Manizales
 %
 %   This file is part of MATPOWER.
 %   Covered by the 3-clause BSD License (see LICENSE file for details).

--- a/lib/mpver.m
+++ b/lib/mpver.m
@@ -16,7 +16,7 @@ function rv = mpver(varargin)
 % and any optional |MATPOWER| packages.
 
 %   MATPOWER
-%   Copyright (c) 2005-2024, Power Systems Engineering Research Center (PSERC)
+%   Copyright (c) 2005-2025, Power Systems Engineering Research Center (PSERC)
 %   by Ray Zimmerman, PSERC Cornell
 %
 %   This file is part of MATPOWER.
@@ -36,7 +36,7 @@ function rv = mpver(varargin)
 v{1} = struct(  'Name',     'MATPOWER', ... 
                 'Version',  '8.0.1-dev', ...
                 'Release',  '', ...
-                'Date',     '08-Mar-2025' );
+                'Date',     '10-May-2025' );
 if nargout > 0
     if nargin > 0
         rv = v{1};

--- a/lib/t/t_case3p_a.m
+++ b/lib/t/t_case3p_a.m
@@ -42,9 +42,9 @@ mpc.line3p = [
 ];
 
 %% transformer
-%	xfid	fbus	tbus	status	R	X	basekVA	basekV
+%	xfid	fbus	tbus	status	R	X	basekVA	basekV  ratio
 mpc.xfmr3p = [
-	1	2	3	1	0.01	0.06	6000	12.47;
+	1	2	3	1	0.01	0.06	6000	12.47   1;
 ];
 
 %% load

--- a/lib/t/t_case3p_a.m
+++ b/lib/t/t_case3p_a.m
@@ -42,9 +42,9 @@ mpc.line3p = [
 ];
 
 %% transformer
-%	xfid	fbus	tbus	status	R	X	basekVA	basekV  ratio
+%	xfid	fbus	tbus	status	R	X	basekVA	basekV	ratio
 mpc.xfmr3p = [
-	1	2	3	1	0.01	0.06	6000	12.47   1;
+	1	2	3	1	0.01	0.06	6000	12.47	1;
 ];
 
 %% load

--- a/lib/t/t_case3p_b.m
+++ b/lib/t/t_case3p_b.m
@@ -85,9 +85,9 @@ mpc.line3p = [
 ];
 
 %% transformer
-%	xfid	fbus	tbus	status	R	X	basekVA	basekV
+%	xfid	fbus	tbus	status	R	X	basekVA	basekV  ratio
 mpc.xfmr3p = [
-	1	2	3	1	0.01	0.06	6000	12.47;
+	1	2	3	1	0.01	0.06	6000	12.47   1;
 ];
 
 %% load

--- a/lib/t/t_case3p_b.m
+++ b/lib/t/t_case3p_b.m
@@ -85,9 +85,9 @@ mpc.line3p = [
 ];
 
 %% transformer
-%	xfid	fbus	tbus	status	R	X	basekVA	basekV  ratio
+%	xfid	fbus	tbus	status	R	X	basekVA	basekV	ratio
 mpc.xfmr3p = [
-	1	2	3	1	0.01	0.06	6000	12.47   1;
+	1	2	3	1	0.01	0.06	6000	12.47	1;
 ];
 
 %% load

--- a/lib/t/t_case3p_c.m
+++ b/lib/t/t_case3p_c.m
@@ -88,9 +88,9 @@ mpc.line3p = [
 ];
 
 %% transformer
-%	xfid	fbus	tbus	status	R	X	basekVA	basekV  ratio
+%	xfid	fbus	tbus	status	R	X	basekVA	basekV	ratio
 mpc.xfmr3p = [
-	1	2	3	1	0.01	0.06	6000	12.47   1;
+	1	2	3	1	0.01	0.06	6000	12.47	1;
 ];
 
 %% load

--- a/lib/t/t_case3p_c.m
+++ b/lib/t/t_case3p_c.m
@@ -88,9 +88,9 @@ mpc.line3p = [
 ];
 
 %% transformer
-%	xfid	fbus	tbus	status	R	X	basekVA	basekV
+%	xfid	fbus	tbus	status	R	X	basekVA	basekV  ratio
 mpc.xfmr3p = [
-	1	2	3	1	0.01	0.06	6000	12.47;
+	1	2	3	1	0.01	0.06	6000	12.47   1;
 ];
 
 %% load

--- a/lib/t/t_case3p_d.m
+++ b/lib/t/t_case3p_d.m
@@ -86,9 +86,9 @@ mpc.line3p = [
 ];
 
 %% transformer
-%	xfid	fbus	tbus	status	R	X	basekVA	basekV  ratio
+%	xfid	fbus	tbus	status	R	X	basekVA	basekV	ratio
 mpc.xfmr3p = [
-	1	2	3	1	0.01	0.06	6000	12.47   1;
+	1	2	3	1	0.01	0.06	6000	12.47	1;
 ];
 
 %% load

--- a/lib/t/t_case3p_d.m
+++ b/lib/t/t_case3p_d.m
@@ -86,9 +86,9 @@ mpc.line3p = [
 ];
 
 %% transformer
-%	xfid	fbus	tbus	status	R	X	basekVA	basekV
+%	xfid	fbus	tbus	status	R	X	basekVA	basekV  ratio
 mpc.xfmr3p = [
-	1	2	3	1	0.01	0.06	6000	12.47;
+	1	2	3	1	0.01	0.06	6000	12.47   1;
 ];
 
 %% load

--- a/lib/t/t_case3p_e.m
+++ b/lib/t/t_case3p_e.m
@@ -86,9 +86,9 @@ mpc.line3p = [
 ];
 
 %% transformer
-%	xfid	fbus	tbus	status	R	X	basekVA	basekV  ratio
+%	xfid	fbus	tbus	status	R	X	basekVA	basekV	ratio
 mpc.xfmr3p = [
-	1	2	3	1	0.01	0.06	6000	12.47   1;
+	1	2	3	1	0.01	0.06	6000	12.47	1;
 ];
 
 %% load

--- a/lib/t/t_case3p_e.m
+++ b/lib/t/t_case3p_e.m
@@ -86,9 +86,9 @@ mpc.line3p = [
 ];
 
 %% transformer
-%	xfid	fbus	tbus	status	R	X	basekVA	basekV
+%	xfid	fbus	tbus	status	R	X	basekVA	basekV  ratio
 mpc.xfmr3p = [
-	1	2	3	1	0.01	0.06	6000	12.47;
+	1	2	3	1	0.01	0.06	6000	12.47   1;
 ];
 
 %% load

--- a/lib/t/t_case3p_f.m
+++ b/lib/t/t_case3p_f.m
@@ -99,11 +99,11 @@ mpc.line3p = [
 ];
 
 %% transformer
-%	xfid	fbus	tbus	status	R	X	basekVA	basekV  ratio
+%	xfid	fbus	tbus	status	R	X	basekVA	basekV	ratio
 mpc.xfmr3p = [
-	1	2	3	1	0.01	0.06	6000	12.47   1;
-	2	6	7	1	0.01	0.06	6000	12.47   1;
-	3	10	11	1	0.01	0.06	6000	12.47   1;
+	1	2	3	1	0.01	0.06	6000	12.47	1;
+	2	6	7	1	0.01	0.06	6000	12.47	1;
+	3	10	11	1	0.01	0.06	6000	12.47	1;
 ];
 
 %% load

--- a/lib/t/t_case3p_f.m
+++ b/lib/t/t_case3p_f.m
@@ -99,11 +99,11 @@ mpc.line3p = [
 ];
 
 %% transformer
-%	xfid	fbus	tbus	status	R	X	basekVA	basekV
+%	xfid	fbus	tbus	status	R	X	basekVA	basekV  ratio
 mpc.xfmr3p = [
-	1	2	3	1	0.01	0.06	6000	12.47;
-	2	6	7	1	0.01	0.06	6000	12.47;
-	3	10	11	1	0.01	0.06	6000	12.47;
+	1	2	3	1	0.01	0.06	6000	12.47   1;
+	2	6	7	1	0.01	0.06	6000	12.47   1;
+	3	10	11	1	0.01	0.06	6000	12.47   1;
 ];
 
 %% load

--- a/lib/t/t_case3p_g.m
+++ b/lib/t/t_case3p_g.m
@@ -100,11 +100,11 @@ mpc.line3p = [
 ];
 
 %% transformer
-%	xfid	fbus	tbus	status	R	X	basekVA	basekV
+%	xfid	fbus	tbus	status	R	X	basekVA	basekV  ratio
 mpc.xfmr3p = [
-	1	2	3	1	0.01	0.06	6000	12.47;
-	2	6	7	1	0.01	0.06	6000	12.47;
-	3	10	11	1	0.01	0.06	6000	12.47;
+	1	2	3	1	0.01	0.06	6000	12.47   1;
+	2	6	7	1	0.01	0.06	6000	12.47   1;
+	3	10	11	1	0.01	0.06	6000	12.47   1;
 ];
 
 %% load

--- a/lib/t/t_case3p_g.m
+++ b/lib/t/t_case3p_g.m
@@ -100,11 +100,11 @@ mpc.line3p = [
 ];
 
 %% transformer
-%	xfid	fbus	tbus	status	R	X	basekVA	basekV  ratio
+%	xfid	fbus	tbus	status	R	X	basekVA	basekV	ratio
 mpc.xfmr3p = [
-	1	2	3	1	0.01	0.06	6000	12.47   1;
-	2	6	7	1	0.01	0.06	6000	12.47   1;
-	3	10	11	1	0.01	0.06	6000	12.47   1;
+	1	2	3	1	0.01	0.06	6000	12.47	1;
+	2	6	7	1	0.01	0.06	6000	12.47	1;
+	3	10	11	1	0.01	0.06	6000	12.47	1;
 ];
 
 %% load

--- a/lib/t/t_case3p_h.m
+++ b/lib/t/t_case3p_h.m
@@ -101,11 +101,11 @@ mpc.line3p = [
 ];
 
 %% transformer
-%	xfid	fbus	tbus	status	R	X	basekVA	basekV  ratio
+%	xfid	fbus	tbus	status	R	X	basekVA	basekV	ratio
 mpc.xfmr3p = [
-	1	2	3	1	0.01	0.06	6000	12.47   1;
-	2	6	7	1	0.01	0.06	6000	12.47   1;
-	3	10	11	1	0.01	0.06	6000	12.47   1;
+	1	2	3	1	0.01	0.06	6000	12.47	1;
+	2	6	7	1	0.01	0.06	6000	12.47	1;
+	3	10	11	1	0.01	0.06	6000	12.47	1;
 ];
 
 %% load

--- a/lib/t/t_case3p_h.m
+++ b/lib/t/t_case3p_h.m
@@ -101,11 +101,11 @@ mpc.line3p = [
 ];
 
 %% transformer
-%	xfid	fbus	tbus	status	R	X	basekVA	basekV
+%	xfid	fbus	tbus	status	R	X	basekVA	basekV  ratio
 mpc.xfmr3p = [
-	1	2	3	1	0.01	0.06	6000	12.47;
-	2	6	7	1	0.01	0.06	6000	12.47;
-	3	10	11	1	0.01	0.06	6000	12.47;
+	1	2	3	1	0.01	0.06	6000	12.47   1;
+	2	6	7	1	0.01	0.06	6000	12.47   1;
+	3	10	11	1	0.01	0.06	6000	12.47   1;
 ];
 
 %% load


### PR DESCRIPTION
The following subclasses were modified to include a tap ratio parameter in the modeling of three-phase transformers:

1. `dmce_xfmr3p_mpc2`
2. `dme_xfmr3p`
3. `nme_xfmr3p`

Moreover, all the prototype data formats for three-phase cases were modified to include a new column for the tap ratio.